### PR TITLE
Fixed BuildTools Downloading

### DIFF
--- a/buildtools-integration/buildtools.js
+++ b/buildtools-integration/buildtools.js
@@ -20,7 +20,7 @@ var buildtools = {};
  * @param cb Run when downloaded
  */
 buildtools.download = function(cwd,filename,cb) {
-  request('https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar', cb).on('response', (res) => res.pipe(fs.createWriteStream(cwd+filename))).on('error', (err) => Console.error("There Was An Error Downloading Build Tools:", err))
+  request("https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar", cb).on("response", (res) => res.pipe(fs.createWriteStream(cwd+filename))).on("error", (err) => Console.error("There Was An Error Downloading Build Tools:", err));
 };
 
 /**

--- a/buildtools-integration/buildtools.js
+++ b/buildtools-integration/buildtools.js
@@ -20,7 +20,7 @@ var buildtools = {};
  * @param cb Run when downloaded
  */
 buildtools.download = function(cwd,filename,cb) {
-  request('https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar', cb).on('response', (res) => res.pipe(fs.createWriteStream(cwd+filename))).on('error', (err) => console.error("There Was An Error Downloading Build Tools:", err))
+  request('https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar', cb).on('response', (res) => res.pipe(fs.createWriteStream(cwd+filename))).on('error', (err) => Console.error("There Was An Error Downloading Build Tools:", err))
 };
 
 /**

--- a/buildtools-integration/buildtools.js
+++ b/buildtools-integration/buildtools.js
@@ -20,7 +20,7 @@ var buildtools = {};
  * @param cb Run when downloaded
  */
 buildtools.download = function(cwd,filename,cb) {
-    request('https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar', cb).pipe(fs.createWriteStream(cwd+filename))
+  request('https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar', cb).on('response', (res) => res.pipe(fs.createWriteStream(cwd+filename))).on('error', (err) => console.error("There Was An Error Downloading Build Tools:", err))
 };
 
 /**

--- a/buildtools-integration/buildtools.js
+++ b/buildtools-integration/buildtools.js
@@ -20,7 +20,7 @@ var buildtools = {};
  * @param cb Run when downloaded
  */
 buildtools.download = function(cwd,filename,cb) {
-  request("https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar", cb).on("response", (res) => res.pipe(fs.createWriteStream(cwd+filename))).on("error", (err) => Console.error("There Was An Error Downloading Build Tools:", err));
+  request("https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar", cb).on("response", (res) => res.pipe(fs.createWriteStream(cwd+filename))).on("error", (err) => console.error("There Was An Error Downloading Build Tools:", err));
 };
 
 /**

--- a/minecraftserver-integration/server.js
+++ b/minecraftserver-integration/server.js
@@ -1,4 +1,5 @@
 var events = require('events');
+var path = require('path');
 
 var spawn = require('child_process').spawn;
 
@@ -29,10 +30,10 @@ server.start = function(cb) {
             '-jar', server.FileName,
             '--world-dir', server.worldsDir,
             '--plugins', server.pluginsDir,
-            '--bukkit-settings', server.configDirectory + "bukkit.yml",
-            '--commands-settings', server.configDirectory + "commands.yml",
-            '--config', server.configDirectory + "config.yml",
-            '--spigot-settings', server.configDirectory + "spigot.yml"
+            '--bukkit-settings', server.configDirectory + path.sep + "bukkit.yml",
+            '--commands-settings', server.configDirectory + path.sep + "commands.yml",
+            '--config', server.configDirectory + path.sep + "config.yml",
+            '--spigot-settings', server.configDirectory + path.sep + "spigot.yml"
         ], {
             cwd: server.path
         });


### PR DESCRIPTION
Downloading BuildTools Would Creating A Blank File Without The Downloaded Content Of BuildTools. This Fixes That So It Downloads And Can Be Used.